### PR TITLE
Improve logging of NtCreateFile and NtOpenFile

### DIFF
--- a/flags/file.rst
+++ b/flags/file.rst
@@ -181,6 +181,17 @@ Value::
     FILE_OVERWRITE
     FILE_OVERWRITE_IF
 
+NtCreateFile_IoStatusBlock_Information
+======================================
+
+Value::
+
+    FILE_CREATED
+    FILE_OPENED
+    FILE_OVERWRITTEN
+    FILE_SUPERSEDED
+    FILE_EXISTS
+    FILE_DOES_NOT_EXIST
 
 FileOptions
 ===========

--- a/inc/ntapi.h
+++ b/inc/ntapi.h
@@ -746,4 +746,11 @@ static inline UNICODE_STRING *unistr_from_objattr(OBJECT_ATTRIBUTES *obj)
 #define LDR_DLL_NOTIFICATION_REASON_LOADED 1
 #define LDR_DLL_NOTIFICATION_REASON_UNLOADED 2
 
+#define FILE_SUPERSEDED                   0x00000000
+#define FILE_OPENED                       0x00000001
+#define FILE_CREATED                      0x00000002
+#define FILE_OVERWRITTEN                  0x00000003
+#define FILE_EXISTS                       0x00000004
+#define FILE_DOES_NOT_EXIST               0x00000005
+
 #endif

--- a/sigs/file_native.rst
+++ b/sigs/file_native.rst
@@ -115,9 +115,11 @@ Flags::
     desired_access
     share_access
     open_options
+    status_info IoStatusBlock->Information NtCreateFile_IoStatusBlock_Information
 
 Pre::
 
+    IoStatusBlock->Information = 6;
     uint32_t share_access = ShareAccess;
     ShareAccess |= FILE_SHARE_READ;
 
@@ -136,6 +138,7 @@ Logging::
     i share_access share_access
     u filepath filepath
     u filepath_r filepath_r
+    l status_info IoStatusBlock->Information
 
 Post::
 

--- a/sigs/file_native.rst
+++ b/sigs/file_native.rst
@@ -30,9 +30,15 @@ Flags::
     share_access
     create_disposition
     create_options
+    status_info IoStatusBlock->Information NtCreateFile_IoStatusBlock_Information
+
+Ensure::
+
+    IoStatusBlock
 
 Pre::
 
+    memset(IoStatusBlock, 0, sizeof(IO_STATUS_BLOCK));
     uint32_t share_access = ShareAccess;
     ShareAccess |= FILE_SHARE_READ;
 
@@ -51,6 +57,7 @@ Logging::
     i share_access share_access
     u filepath filepath
     u filepath_r filepath_r
+    l status_info IoStatusBlock->Information
 
 Post::
 

--- a/sigs/file_native.rst
+++ b/sigs/file_native.rst
@@ -32,13 +32,9 @@ Flags::
     create_options
     status_info IoStatusBlock->Information NtCreateFile_IoStatusBlock_Information
 
-Ensure::
-
-    IoStatusBlock
-
 Pre::
 
-    memset(IoStatusBlock, 0, sizeof(IO_STATUS_BLOCK));
+    IoStatusBlock->Information = 6;
     uint32_t share_access = ShareAccess;
     ShareAccess |= FILE_SHARE_READ;
 


### PR DESCRIPTION
This PR makes monitor logs IoStatusBlock->Information (See [NtCreateFile doc](https://msdn.microsoft.com/en-us/library/bb432380%28v=vs.85%29.aspx)) for both NtCreateFile and NtOpenfile syscalls.
This value is a flag which indicates what actually happen to the file.