### PR TITLE
add exploit detections & fix unicode leakage bug

### DIFF
--- a/inc/exploit_detection.h
+++ b/inc/exploit_detection.h
@@ -1,0 +1,38 @@
+#ifndef MONITOR_EXPLOIT_DETECTION_H
+#define MONITOR_EXPLOIT_DETECTION_H
+
+#include <winnt.h>
+#include "native.h"
+
+static inline NT_TIB *get_tib()
+{
+	NT_TIB *pTib;
+	#if !__x86_64__
+	__asm__ volatile("movl %%fs:0x18, %0" : "=r" (pTib) : );
+	#else
+	pTib = (NT_TIB*)NtCurrentTeb();
+	#endif
+	return pTib;
+}
+
+static inline PVOID getStackPointer()
+{
+    PVOID ret;
+	#if !__x86_64__
+    __asm__ volatile("movl %%esp, %0" : "=r" (ret));
+	#else
+	__asm__ volatile("mov %%rsp, %0" : "=r" (ret));
+	#endif
+    return ret;
+}
+
+static DWORD EXECUTE_PROTECTIONS = (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY);
+
+BOOL stackPivotDetection();
+void getStackBoundaries(PVOID *sb, PVOID *sl);
+BOOL isAddressInStack(PVOID addr);
+BOOL isAddressInHeap(PVOID addr);
+BOOL stackDEPBypass(HANDLE hProcess, PVOID addr, DWORD new_protection);
+BOOL heapDEPBypass(HANDLE hProcess, PVOID addr, DWORD new_protection);
+
+#endif

--- a/sigs/network.rst
+++ b/sigs/network.rst
@@ -29,11 +29,13 @@ Pre::
 
     wchar_t *filepath = get_unicode_buffer();
     path_get_full_pathW(szFileName, filepath);
+    BOOL bStackPivot = stackPivotDetection();
 
 Logging::
 
     u filepath filepath
     u filepath_r szFileName
+    i StackPivot bStackPivot
 
 Post::
 

--- a/sigs/process.rst
+++ b/sigs/process.rst
@@ -46,6 +46,7 @@ Pre::
 
     wchar_t *filepath = get_unicode_buffer();
     path_get_full_pathW(lpApplicationName, filepath);
+    BOOL bStackPivot = stackPivotDetection();
 
 Interesting::
 
@@ -64,6 +65,7 @@ Logging::
     i thread_identifier lpProcessInformation->dwThreadId
     p process_handle lpProcessInformation->hProcess
     p thread_handle lpProcessInformation->hThread
+    i StackPivot bStackPivot
 
 Post::
 

--- a/sigs/process_native.rst
+++ b/sigs/process_native.rst
@@ -33,6 +33,7 @@ Pre::
     if(ObjectAttributes != NULL && ObjectAttributes->ObjectName != NULL) {
         filepath_r = ObjectAttributes->ObjectName->Buffer;
     }
+    BOOL bStackPivot = stackPivotDetection();
 
 Interesting::
 
@@ -44,6 +45,7 @@ Logging::
 
     u filepath filepath
     u filepath_r filepath_r
+    i StackPivot bStackPivot
 
 Post::
 
@@ -83,6 +85,7 @@ Pre::
     if(ObjectAttributes != NULL && ObjectAttributes->ObjectName != NULL) {
         filepath_r = ObjectAttributes->ObjectName->Buffer;
     }
+    BOOL bStackPivot = stackPivotDetection();
 
 Interesting::
 
@@ -94,6 +97,7 @@ Logging::
 
     u filepath filepath
     u filepath_r filepath_r
+    i StackPivot bStackPivot
 
 Post::
 
@@ -155,6 +159,7 @@ Pre::
         extract_unicode_string(&ProcessParameters->ImagePathName);
     wchar_t *command_line =
         extract_unicode_string(&ProcessParameters->CommandLine);
+    BOOL bStackPivot = stackPivotDetection();
 
 Logging::
 
@@ -164,6 +169,7 @@ Logging::
     u thread_name_r thread_name_r
     u filepath filepath
     u command_line command_line
+    i StackPivot bStackPivot
 
 Post::
 
@@ -206,6 +212,7 @@ Pre::
     if(ImagePath != NULL) {
         filepath_r = ImagePath->Buffer;
     }
+    BOOL bStackPivot = stackPivotDetection();
 
 Interesting::
 
@@ -217,6 +224,7 @@ Logging::
 
     u filepath filepath
     u filepath_r filepath_r
+    i StackPivot bStackPivot
 
 Post::
 
@@ -401,6 +409,19 @@ Flags::
     protection
     allocation_type
 
+Pre::
+
+    PVOID BaseAddress_orig = *BaseAddress;
+    BOOL bStackPivotDetected = stackPivotDetection();
+    BOOL bStackDEPBypass = isAddressInStack(BaseAddress_orig);
+    BOOL bHeapDEPBypass = heapDEPBypass(ProcessHandle, BaseAddress_orig, Protect);
+
+Logging::
+
+    i StackPivot bStackPivotDetected
+    i StackDEPBypass bStackDEPBypass
+    i HeapDEPBypass bHeapDEPBypass
+
 
 NtReadVirtualMemory
 ===================
@@ -457,6 +478,18 @@ Flags::
 
     protection
 
+Pre::
+
+    PVOID BaseAddress_orig = *BaseAddress;
+    BOOL bStackPivotDetected = stackPivotDetection();
+    BOOL bStackDEPBypass = isAddressInStack(BaseAddress_orig);
+    BOOL bHeapDEPBypass = heapDEPBypass(ProcessHandle, BaseAddress_orig, NewAccessProtection);
+
+Logging::
+
+    i StackPivot bStackPivotDetected
+    i StackDEPBypass bStackDEPBypass
+    i HeapDEPBypass bHeapDEPBypass
 
 NtFreeVirtualMemory
 ===================

--- a/sigs/system.rst
+++ b/sigs/system.rst
@@ -103,11 +103,13 @@ Pre::
     char library[MAX_PATH];
     wchar_t *module_name = extract_unicode_string(ModuleFileName);
     library_from_unicode_string(ModuleFileName, library, sizeof(library));
+    BOOL bStackPivot = stackPivotDetection();
 
 Logging::
 
     u module_name module_name
     s basename library
+    i StackPivot bStackPivot
 
 Post::
 
@@ -184,6 +186,7 @@ Parameters::
 Pre::
 
     wchar_t *module_name = extract_unicode_string(ModuleFileName);
+    BOOL bStackPivot = stackPivotDetection();
 
 Middle::
 
@@ -194,6 +197,7 @@ Middle::
 Logging::
 
     u module_name module_name
+    i StackPivot bStackPivot
 
 Post::
 

--- a/src/exploit_detection.c
+++ b/src/exploit_detection.c
@@ -1,0 +1,70 @@
+#include <windows.h>
+#include <winnt.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "exploit_detection.h"
+#include "native.h"
+#include "pipe.h"
+#include "misc.h"
+#include "symbol.h"
+
+BOOL stackPivotDetection()
+{
+	BOOL ret = FALSE;
+	PVOID esp = getStackPointer(); 
+	
+	ret = !isAddressInStack(esp);
+	return ret;
+}
+
+void getStackBoundaries(PVOID *sb, PVOID *sl)
+{
+	NT_TIB *tib = NULL;
+	tib = get_tib();
+	*sb = tib->StackBase;
+	*sl = tib->StackLimit;
+}
+
+BOOL isAddressInStack(PVOID addr)
+{
+	BOOL ret = FALSE;
+	PVOID pStackBase = NULL, pStackLimit = NULL;
+	
+	getStackBoundaries(&pStackBase, &pStackLimit);
+	ret = (addr <= pStackBase && addr >= pStackLimit);
+	return ret;
+}
+
+// Currently we just check if the memory block is of MEM_PRIVATE type.
+// There are some APIs for traversing the heap, but they might miss
+// some of the heap blocks (VirtualAllocBlocks for example).
+BOOL isAddressInHeap(PVOID addr)
+{
+	BOOL ret = FALSE;
+	MEMORY_BASIC_INFORMATION_CROSS mbi;
+	virtual_query(addr, &mbi);
+	ret = (mbi.Type == MEM_PRIVATE);
+	return ret;
+}
+
+BOOL stackDEPBypass(HANDLE hProcess, PVOID addr, DWORD new_protection)
+{
+	BOOL ret = FALSE;
+	if (((new_protection & EXECUTE_PROTECTIONS) != 0) && 
+	isAddressInStack(addr) &&
+	(hProcess == get_current_process())) {
+		return TRUE;
+	}
+	return ret;
+}
+
+BOOL heapDEPBypass(HANDLE hProcess, PVOID addr, DWORD new_protection)
+{
+	BOOL ret = FALSE;
+	if (((new_protection & PAGE_EXECUTE_READWRITE) != 0) &&
+	isAddressInHeap(addr) &&
+	(hProcess == get_current_process())) {
+		ret = TRUE;
+	}
+	return ret;
+}

--- a/src/hooking.c
+++ b/src/hooking.c
@@ -35,6 +35,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "symbol.h"
 #include "unhook.h"
 
+#include "exploit_detection.h"
+
 #define MISSING_HANDLE_COUNT 128
 
 static SYSTEM_INFO g_si;

--- a/src/misc.c
+++ b/src/misc.c
@@ -570,7 +570,9 @@ uint32_t path_get_full_pathW(const wchar_t *in, wchar_t *out)
             *ptr = 0;
         }
 
-        if(GetLongPathNameW(pathi, patho, MAX_PATH_W+1) != 0) {
+        // if(GetLongPathNameW(pathi, patho, MAX_PATH_W+1) != 0) {
+        uint32_t length = GetFullPathNameW(pathi, MAX_PATH_W + 1, patho, NULL);
+        if (length != 0) {
             // Copy the first part except for the "\\\\?\\" part.
             if(wcsnicmp(patho, L"\\\\?\\", 4) == 0) {
                 wcscpy(out, patho + 4);
@@ -589,6 +591,12 @@ uint32_t path_get_full_pathW(const wchar_t *in, wchar_t *out)
             free_unicode_buffer(buf1);
             free_unicode_buffer(buf2);
             return lstrlenW(out);
+        }
+        else {
+            *out = 0;
+            free_unicode_buffer(buf1);
+            free_unicode_buffer(buf2);
+            return 0;
         }
 
         last_ptr = ptr;


### PR DESCRIPTION
exploit_detection implements 2 detections:
1. Stack Pivot detection
2. Changing heap/stack page to executable

the first shouldn't have any false negatives, the second has a lot.
we also replaced GetLongPathName to GetFullPathName as it solves the
unicode buffers leakage bug.