### PR TITLE
Check length of haystack in our_memmem

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -1502,6 +1502,10 @@ uint8_t *our_memmem(
         idx = &_idx;
     }
 
+    if (haylength < needlength) {
+        return NULL;
+    }
+
     for (; *idx < haylength - needlength + 1; *idx += 1) {
         if(memcmp(&haystack[*idx], needle, needlength) == 0) {
             return &haystack[*idx];


### PR DESCRIPTION
Since unsigned ints are used, the subtraction of a small haystack and
large needle would produce a very large number. This could lead to a
segmentation fault if the comparison goes on too far past the end of one
of the arrays.