### PR TITLE
redundant argnum--

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -414,7 +414,6 @@ void log_api(uint32_t index, int is_success, uintptr_t return_value,
         // report we turn it into a buffer (much like the dropped files).
         if(*fmt == '!') {
             override = 1;
-            argnum--;
             fmt++;
         }
 


### PR DESCRIPTION
this 'argnum--;' call statement should be removed because it would be cause some errors in processing logs for some api parameter types.