### PR TITLE
Typo correction in signature file ui.rst

### DIFF
--- a/sigs/ui.rst
+++ b/sigs/ui.rst
@@ -289,7 +289,7 @@ Logging::
     u string buf
 
 
-_CreateWindowExA
+CreateWindowExA
 ================
 
 Signature::
@@ -317,7 +317,7 @@ Flags::
     style
 
 
-_CreateWindowExW
+CreateWindowExW
 ================
 
 Signature::


### PR DESCRIPTION
Corrected typos for function '_CreateWindowExW' and '_CreateWindowExA' to 'CreateWindowExW' and 'CreateWindowExA'. After this fix, CreateWindow calls are now captured in cuckoo report along with their parameters.