### PR TITLE
Fix the function _hook_determine_start so the monitor works on modern win10 OS

### DIFF
--- a/src/hooking.c
+++ b/src/hooking.c
@@ -571,12 +571,17 @@ static int _hook_determine_start(hook_t *h)
             continue;
         }
 
-        // jmp dword [addr]
-        if(*addr == 0xff && addr[1] == 0x25) {
-            unhook_detect_add_region(h->funcname, addr, addr, addr, 6);
-
+        // jmp dword [addr] / jmp qword [addr]
+        if((*addr == 0xff && addr[1] == 0x25) || (*addr == 0x48 && addr[1] == 0xff && addr[2] == 0x25)) {
+            if(*addr == 0xff)
+                unhook_detect_add_region(h->funcname, addr, addr, addr, 6);
+            else
+                unhook_detect_add_region(h->funcname, addr, addr, addr, 7);
 #if __x86_64__
-            addr += *(int32_t *)(addr + 2) + 6;
+            if(*addr == 0xff)
+                addr += *(int32_t *)(addr + 2) + 6;
+            else
+                addr += *(int32_t *)(addr + 3) + 7;     
 #else
             addr = *(uint8_t **)(addr + 2);
 #endif

--- a/utils/process.py
+++ b/utils/process.py
@@ -467,7 +467,7 @@ class SignatureProcessor(object):
             sigs.append({
                 "library": insn["module_clean"],
                 "apiname": insn["funcname"],
-                "ignore": last == insn["funcname"],
+                "ignore": last == insn["module"] + insn["funcname"],
                 "is_insn": True,
                 "is_hook": True,
                 "signature": {
@@ -479,7 +479,7 @@ class SignatureProcessor(object):
                 },
                 "logging": logging,
             })
-            last = insn["funcname"]
+            last = insn["module"] + insn["funcname"]
 
         # Assign hook indices accordingly (in a sorted manner).
         for idx, sig in enumerate(sigs):


### PR DESCRIPTION
This commit fixes the function _hook_determine_start.
On Windows 10 x64, the monitor fails to restore original API function after executing the hook and the process where it is injected crashes.
It follows the jump when there is a stub for example from kernel32 to kernelbase but it doesn't handle the case when the stub is a jmp qword [addr] so when the address begins with 48 FF 25.