### PR TITLE
Fix handling for "0x48 0xff 0x25" instruction in hook_create_stub function

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ monitor
 The new Cuckoo Monitor. [Click here for documentation][docs].
 If at first it doesn't compile, just try a second time!
 
-Note that you'll need the `pyyaml` package, which may be installed as follows:
-`pip install pyyaml`.
+**New Features:**
+- Now supports running in Windows 10 and Windows 11 guest environments.
+
+**Notes:**
+- The issue with x86-64 samples where hooks could not jump back to the original function execution flow has been resolved. There may still be other issues, which are currently under development and testing.
+
+- Note that you'll need the `pyyaml` package, which may be installed as follows:
+ `pip install pyyaml`.
 
 [docs]: http://cuckoo-monitor.readthedocs.org/en/latest/


### PR DESCRIPTION
**Issue:**
In x86-64 architecture, particularly under Windows 10 and Windows 11, imported functions fail to correctly jump to the original execution flow after hooking.

**Changes:**
Added handling for the "0x48 0xff 0x25" instruction in the `hook_create_stub` function to resolve the issue. This change ensures correct redirection to the original execution path after hooking imported functions.

**Testing:**
Thoroughly tested on Windows 10 and Windows 11 environments to validate the fix's effectiveness and stability.